### PR TITLE
InitalizeOrder: api failure fix due to location_id passed as null for some items

### DIFF
--- a/packages/theme/pages/Cart.vue
+++ b/packages/theme/pages/Cart.vue
@@ -224,30 +224,34 @@ export default {
             if (newValue?.message?.quote && polling.value) {
               stopPolling();
               const updatedCartData = cart.value.items.map((cartItem) => {
-                if (cartItem.updatedCount) cartItem.updatedCount = null;
-                if (cartItem.updatedPrice) cartItem.updatedPrice = null;
                 const quoteItem = newValue.message.quote?.items.filter(
                   (quoteItem) => quoteItem.id === cartItem.id
                 )[0];
+
+                const updatedCartItem = { ...quoteItem, ...cartItem };
+                if (updatedCartItem.updatedCount) updatedCartItem.updatedCount = null;
+                if (updatedCartItem.updatedPrice) updatedCartItem.updatedPrice = null;
+
                 if (
-                  parseFloat(cartItem.price.value) !==
+                  parseFloat(updatedCartItem.price.value) !==
                   parseFloat(quoteItem.price.value)
                 ) {
-                  cartItem.updatedPrice = quoteItem.price.value;
+                  updatedCartItem.updatedPrice = quoteItem.price.value;
                   errPricechange.value = true;
                 }
-                if (cartItem.quantity !== quoteItem.quantity.selected.count) {
-                  cartItem.updatedCount = quoteItem.quantity.selected.count;
+                if (updatedCartItem.quantity !== quoteItem.quantity.selected.count) {
+                  updatedCartItem.updatedCount = quoteItem.quantity.selected.count;
                   if (quoteItem.quantity.selected.count === 0)
                     errOutOfStock.value = true;
                   else errUpdateCount.value = true;
                 }
-                return cartItem;
+                return updatedCartItem;
               });
               cart.value.items = updatedCartData;
               cart.value.quote = newValue?.message?.quote.quote;
               cart.value.totalPrice = parseFloat(newValue?.message?.quote?.quote?.price?.value);
               setCart(cart.value);
+              localStorage.setItem('cartData', JSON.stringify(cart.value));
               enableLoader.value = false;
             }
           }

--- a/packages/theme/pages/Checkout.vue
+++ b/packages/theme/pages/Checkout.vue
@@ -70,7 +70,12 @@
           <div class="s-p-name">{{ cartGetters.getItemName(product) }}</div>
           <div class="s-p-weight">x {{ cartGetters.getItemQty(product) }}</div>
           <div class="s-p-price">
-            ₹ {{ cartGetters.getUpdatedPrice(product) ? cartGetters.getUpdatedPrice(product) : cartGetters.getItemPrice(product).regular }}
+            ₹
+            {{
+              cartGetters.getUpdatedPrice(product)
+                ? cartGetters.getUpdatedPrice(product)
+                : cartGetters.getItemPrice(product).regular
+            }}
           </div>
         </div>
       </div>
@@ -183,12 +188,12 @@
             <div class="">{{ policyObj.descriptor.name }}</div>
             <div class="address-text">{{ policyObj.descriptor.code }}</div>
           </CardContent> -->
-          <!-- <div><hr class="sf-divider divider" /></div>
+      <!-- <div><hr class="sf-divider divider" /></div>
           <CardContent class="flex-space-bw">
             <div class="address-text bold">Total</div>
             <div class="address-text bold">₹{{ cart.quote.price.value }}</div>
           </CardContent> -->
-        <!-- </template>
+      <!-- </template>
       </Card> -->
     </div>
     <Footer
@@ -318,7 +323,7 @@ export default {
 
     const { init: getOrderPolicy } = useOrderPolicy();
 
-    const policy = ref({cancellation_reasons: []});
+    const policy = ref({ cancellation_reasons: [] });
     const {
       getBillngAddress,
       getShippingAddress,
@@ -412,7 +417,6 @@ export default {
               transactionId: transactionId.value
             })
           );
-          localStorage.removeItem('transactionId');
           // enableLoader.value = false;
           context.root.$router.push({
             path: '/payment',
@@ -431,7 +435,7 @@ export default {
         context: {
           bpp_id: cart.value.bpp.id
         }
-      }).then((res)=>{
+      }).then((res) => {
         policy.value = res.message;
       });
     });

--- a/packages/theme/pages/Payment.vue
+++ b/packages/theme/pages/Payment.vue
@@ -1,7 +1,7 @@
 <template>
   <div id="payment">
     <div class="top-bar header-top">
-      <div class="sf-chevron--left sf-chevron icon_back">
+      <div @click="goBack" class="sf-chevron--left sf-chevron icon_back">
         <span class="sf-search-bar__icon">
           <SfIcon color="var(--c-primary)" size="20px" icon="chevron_left" />
         </span>
@@ -22,12 +22,16 @@
           class="flex-space-bw"
         >
           <div class="address-text">{{ breakup.title }}</div>
-          <div class="address-text">₹{{ parseFloat(breakup.price.value).toFixed( 2 ) }}</div>
+          <div class="address-text">
+            ₹{{ parseFloat(breakup.price.value).toFixed(2) }}
+          </div>
         </CardContent>
         <div><hr class="sf-divider divider" /></div>
         <CardContent class="flex-space-bw">
           <div class="address-text bold">Total</div>
-          <div class="address-text bold">₹{{ order.cart.quote.price.value }}</div>
+          <div class="address-text bold">
+            ₹{{ order.cart.quote.price.value }}
+          </div>
         </CardContent>
       </Card>
       <div class="sub-heading">
@@ -52,7 +56,7 @@
       class="footer-fixed"
       :buttonText="'Pay & Confirm'"
       :buttonEnable="isPayConfirmActive"
-      :totalPrice="parseFloat(order.cart.quote.price.value) "
+      :totalPrice="parseFloat(order.cart.quote.price.value)"
       :totalItem="cartGetters.getTotalItems(order.cart)"
       @buttonClick="proceedToConfirm"
     >
@@ -84,7 +88,7 @@ import { ref, computed, onBeforeMount, watch } from '@vue/composition-api';
 
 import LoadingCircle from '~/components/LoadingCircle';
 // import helpers from '../helpers/helpers';
-import { useCart, useConfirmOrder, cartGetters } from '@vue-storefront/beckn';
+import { useConfirmOrder, cartGetters } from '@vue-storefront/beckn';
 
 import Card from '~/components/Card.vue';
 
@@ -116,7 +120,6 @@ export default {
       return order.value?.transactionId === context.root.$route.query.id;
     });
 
-    const { clear } = useCart();
     const { init, poll, pollResults } = useConfirmOrder('confirm-order');
 
     const changePaymentMethod = (value) => {
@@ -147,6 +150,8 @@ export default {
       await poll({ messageId: response.context.message_id });
     };
 
+    const goBack = () => context.root.$router.back();
+
     watch(
       () => pollResults.value,
       (newValue) => {
@@ -176,13 +181,13 @@ export default {
         context.root.$router.push('/');
       }
       console.log(order.value);
-      clear();
     });
     return {
       paymentMethod,
       changePaymentMethod,
       order,
       cartGetters,
+      goBack,
       isPayConfirmActive,
       proceedToConfirm,
       isTransactionMatching,


### PR DESCRIPTION
Local storage cart data was not getting updated with the onGetQuote response where we get the location_id for some of the items. Updating the cart data with the onGetQuote response received and setting it to local storage.